### PR TITLE
fix: rename ProjectOptions to project_options

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,10 +1,10 @@
 parse:
   additional_commands:
-    ProjectOptions:
+    project_options:
       pargs:
         nargs: '*'
         flags: []
-      spelling: ProjectOptions
+      spelling: project_options
       kwargs:
         CLANG_WARNINGS: 1
         GCC_WARNINGS: 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ProjectOptions
+# project_options
 
 A general-purpose CMake library that makes using CMake easier
 
@@ -15,10 +15,10 @@ cmake_minimum_required(VERSION 3.16)
 # You can later set fine-grained standards for each target using `target_compile_features`
 # set(CMAKE_CXX_STANDARD 17)
 
-# Add ProjectOptions v0.11.4
+# Add ProjectOptions v0.12.0
 # https://github.com/cpp-best-practices/ProjectOptions
 include(FetchContent)
-FetchContent_Declare(projectoptions URL https://github.com/cpp-best-practices/ProjectOptions/archive/refs/tags/v0.11.4.zip)
+FetchContent_Declare(projectoptions URL https://github.com/cpp-best-practices/ProjectOptions/archive/refs/tags/v0.12.0.zip)
 FetchContent_MakeAvailable(projectoptions)
 include(${projectoptions_SOURCE_DIR}/Index.cmake)
 
@@ -29,9 +29,9 @@ include(${projectoptions_SOURCE_DIR}/Index.cmake)
 # Set the project name and language
 project(myproject LANGUAGES CXX)
 
-# Initialize ProjectOptions
+# Initialize project_options
 # uncomment the options to enable them:
-ProjectOptions(
+project_options(
       ENABLE_CACHE
       ENABLE_CPPCHECK
       ENABLE_CLANG_TIDY
@@ -58,7 +58,7 @@ ProjectOptions(
 
 add_executable(myprogram main.cpp)
 target_compile_features(myprogram INTERFACE cxx_std_17)
-target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect ProjectOptions to myprogram
+target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect project_options to myprogram
 
 # find and link dependencies (assuming you have enabled vcpkg or Conan):
 find_package(fmt REQUIRED)
@@ -69,7 +69,7 @@ target_link_system_libraries(
 )
 ```
 
-## `ProjectOptions` function
+## `project_options` function
 
 It accepts the following named flags:
 
@@ -123,7 +123,7 @@ Similar to `target_include_directories`, but it suppresses the warnings. It is u
 
 ⚠️ It is highly recommended to keep the build declarative and reproducible by using the function arguments as explained above.
 
-However, if you still want to change the CMake options on the fly (e.g., to enable sanitizers inside CI), you can include the `GlobalOptions.cmake`, which adds global options for the arguments of `ProjectOptions` function.
+However, if you still want to change the CMake options on the fly (e.g., to enable sanitizers inside CI), you can include the `GlobalOptions.cmake`, which adds global options for the arguments of `project_options` function.
 
 <details>
 <summary>Click to show the example:</summary>
@@ -137,10 +137,10 @@ cmake_minimum_required(VERSION 3.16)
 # You can later set fine-grained standards for each target using `target_compile_features`
 # set(CMAKE_CXX_STANDARD 17)
 
-# Add ProjectOptions v0.11.4
+# Add ProjectOptions v0.12.0
 # https://github.com/cpp-best-practices/ProjectOptions
 include(FetchContent)
-FetchContent_Declare(projectoptions URL https://github.com/cpp-best-practices/ProjectOptions/archive/refs/tags/v0.11.4.zip)
+FetchContent_Declare(projectoptions URL https://github.com/cpp-best-practices/ProjectOptions/archive/refs/tags/v0.12.0.zip)
 FetchContent_MakeAvailable(projectoptions)
 include(${projectoptions_SOURCE_DIR}/Index.cmake)
 
@@ -154,9 +154,9 @@ include(${projectoptions_SOURCE_DIR}/src/GlobalOptions.cmake)
 # Set the project name and language
 project(myproject LANGUAGES CXX)
 
-# Initialize ProjectOptions
+# Initialize project_options
 # uncomment the options to enable them:
-ProjectOptions(
+project_options(
       ENABLE_CACHE
       ENABLE_CPPCHECK
       ENABLE_CLANG_TIDY
@@ -182,7 +182,7 @@ ProjectOptions(
 
 add_executable(myprogram main.cpp)
 target_compile_features(myprogram INTERFACE cxx_std_17)
-target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect ProjectOptions to myprogram
+target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect project_options to myprogram
 
 # find and link dependencies (assuming you have enabled vcpkg or Conan):
 find_package(fmt REQUIRED)

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -36,8 +36,8 @@ include("${ProjectOptions_SRC_DIR}/SystemLink.cmake")
 # - GCC_WARNINGS: Override the defaults for the GCC warnings
 # - CONAN_OPTIONS: Extra Conan options
 #
-# NOTE: cmake-lint [C0103] Invalid macro name "ProjectOptions" doesn't match `[0-9A-Z_]+`
-macro(ProjectOptions)
+# NOTE: cmake-lint [C0103] Invalid macro name "project_options" doesn't match `[0-9A-Z_]+`
+macro(project_options)
   set(options
       WARNINGS_AS_ERRORS
       ENABLE_COVERAGE
@@ -61,7 +61,7 @@ macro(ProjectOptions)
   set(oneValueArgs MSVC_WARNINGS CLANG_WARNINGS GCC_WARNINGS)
   set(multiValueArgs PCH_HEADERS CONAN_OPTIONS)
   cmake_parse_arguments(
-    ProjectOptions
+    project_options
     "${options}"
     "${oneValueArgs}"
     "${multiValueArgs}"

--- a/src/Vcpkg.cmake
+++ b/src/Vcpkg.cmake
@@ -6,7 +6,7 @@ macro(run_vcpkg)
   # optional named VCPKG_DIR argument
   set(oneValueArgs VCPKG_DIR)
   cmake_parse_arguments(
-    ProjectOptions
+    project_options
     ""
     "${oneValueArgs}"
     ""

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,10 +4,10 @@ cmake_minimum_required(VERSION 3.16...3.21)
 # You can later set fine-grained standards for each target using `target_compile_features`
 set(CMAKE_CXX_STANDARD 17)
 
-### Add ProjectOptions
+### Add project_options
 # include(FetchContent)
-# FetchContent_Declare(ProjectOptions URL https://github.com/aminya/ProjectOptions/archive/refs/heads/main.zip)
-# FetchContent_MakeAvailable(ProjectOptions)
+# FetchContent_Declare(project_options URL https://github.com/cpp-best-practices/project_options/archive/refs/heads/main.zip)
+# FetchContent_MakeAvailable(project_options)
 # include(${ProjectOptions_SOURCE_DIR}/Index.cmake)
 include(../src/Index.cmake)
 
@@ -18,9 +18,9 @@ project(
   VERSION 0.2.0
   LANGUAGES CXX)
 
-# Initialize ProjectOptions
+# Initialize project_options
 # uncomment the options to enable them
-ProjectOptions(
+project_options(
   ENABLE_CACHE
   # ENABLE_CONAN
   # WARNINGS_AS_ERRORS
@@ -42,7 +42,7 @@ ProjectOptions(
   # ENABLE_SANITIZER_MEMORY
   # CLANG_WARNINGS "-Weverything"
 )
-# NOTE: project_options and project_warnings are defined inside ProjectOptions
+# NOTE: project_options and project_warnings are defined inside project_options
 
 # add src, tests, etc here:
 add_executable(main main.cpp)


### PR DESCRIPTION
BREAKING CHANGE now, you should rename any usage of ProjectOptions to project_options

This was done for consistency with CMake's naming convention