### PR TITLE
fix: add EXISTS keyword to BuildType check

### DIFF
--- a/src/StandardProjectSettings.cmake
+++ b/src/StandardProjectSettings.cmake
@@ -1,5 +1,5 @@
 # Set a default build type if none was specified
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+if(NOT EXISTS CMAKE_BUILD_TYPE AND NOT EXISTS CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
   set(CMAKE_BUILD_TYPE
       RelWithDebInfo


### PR DESCRIPTION
This commit adds the `EXISTS` keyword in the if-statement so that a missing
BUILD_TYPE is realy detected.

This should close #40 