### PR TITLE
fix: use the cmake's include install directory for target_include_system_libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,14 @@ Named String:
 
 ## `target_link_system_libraries` function
 
-A very useful function that accepts the same arguments as `target_link_libraries` while marking their include directories as "SYSTEM", which suppresses their warnings. This helps in enabling `WARNINGS_AS_ERRORS` for your own source code.
+A function that accepts the same arguments as `target_link_libraries`. It has the following features:
+
+- The include directories of the library are included as `SYSTEM` to suppress their warnings. This helps in enabling `WARNINGS_AS_ERRORS` for your own source code.
+- For installation of the package, the includes are considered to be at `${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}`.
 
 ## `target_include_system_directories` function
 
-Similar to `target_include_directories`, but it suppresses the warnings. It is useful if you want to include some external directories directly.
+A function that accepts the same arguments as `target_include_directories`. It has the above mentioned features of `target_link_system_libraries`
 
 ## `target_link_cuda` function
 

--- a/src/SystemLink.cmake
+++ b/src/SystemLink.cmake
@@ -10,15 +10,23 @@ function(target_include_system_directories target)
 
   foreach(scope IN ITEMS INTERFACE PUBLIC PRIVATE)
     foreach(lib_include_dirs IN LISTS ARG_${scope})
-      if(MSVC)
+      if(NOT MSVC)
         # system includes do not work in MSVC
         # awaiting https://gitlab.kitware.com/cmake/cmake/-/issues/18272#
         # awaiting https://gitlab.kitware.com/cmake/cmake/-/issues/17904
-        target_include_directories(${target} ${scope} ${lib_include_dirs})
+        set(_SYSTEM SYSTEM)
+      endif()
+      if(${scope} STREQUAL "INTERFACE" OR ${scope} STREQUAL "PUBLIC")
+        target_include_directories(
+          ${target}
+          ${_SYSTEM}
+          ${scope}
+          "$<BUILD_INTERFACE:${lib_include_dirs}>"
+          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>")
       else()
         target_include_directories(
           ${target}
-          SYSTEM
+          ${_SYSTEM}
           ${scope}
           ${lib_include_dirs})
       endif()
@@ -39,7 +47,7 @@ function(
     if(lib_include_dirs)
       target_include_system_directories(${target} ${scope} ${lib_include_dirs})
     else()
-      message(STATUS "${lib} library does not have the INTERFACE_INCLUDE_DIRECTORIES property.")
+      message(TRACE "${lib} library does not have the INTERFACE_INCLUDE_DIRECTORIES property.")
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
 PUBLIC and INTERFACE mean that when the package is installed, the public/interface headers should be provided on the installed environment. This issue is not seen when a library is linked as private because during the installation, the headers are already built into the library.

Fixes #55 
