### PR TITLE
Make cppcheck flags configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ It gets the following named parameters that can have different values in front o
 - `CLANG_WARNINGS`: Override the defaults for the CLANG warnings
 - `GCC_WARNINGS`: Override the defaults for the GCC warnings
 - `CUDA_WARNINGS`: Override the defaults for the CUDA warnings
+- `CPPCHECK_WARNINGS`: Override the defaults for the options passed to CPPCHECK
 - `CONAN_OPTIONS`: Extra Conan options
 
 ## `run_vcpkg` function

--- a/src/Index.cmake
+++ b/src/Index.cmake
@@ -38,6 +38,7 @@ include("${ProjectOptions_SRC_DIR}/Cuda.cmake")
 # - CLANG_WARNINGS: Override the defaults for the CLANG warnings
 # - GCC_WARNINGS: Override the defaults for the GCC warnings
 # - CUDA_WARNINGS: Override the defaults for the CUDA warnings
+# - CPPCHECK_OPTIONS: Override the defaults for CppCheck settings
 # - CONAN_OPTIONS: Extra Conan options
 #
 # NOTE: cmake-lint [C0103] Invalid macro name "project_options" doesn't match `[0-9A-Z_]+`
@@ -68,6 +69,7 @@ macro(project_options)
       CLANG_WARNINGS
       GCC_WARNINGS
       CUDA_WARNINGS
+      CPPCHECK_OPTIONS
       PCH_HEADERS
       CONAN_OPTIONS)
   cmake_parse_arguments(
@@ -150,7 +152,7 @@ macro(project_options)
   # allow for static analysis options
   include("${ProjectOptions_SRC_DIR}/StaticAnalyzers.cmake")
   if(${ProjectOptions_ENABLE_CPPCHECK})
-    enable_cppcheck()
+    enable_cppcheck("${ProjectOptions_CPPCHECK_OPTIONS}")
   endif()
 
   if(${ProjectOptions_ENABLE_CLANG_TIDY})

--- a/src/StaticAnalyzers.cmake
+++ b/src/StaticAnalyzers.cmake
@@ -1,17 +1,23 @@
-macro(enable_cppcheck)
+macro(enable_cppcheck CPPCHECK_OPTIONS)
   find_program(CPPCHECK cppcheck)
   if(CPPCHECK)
-    # Enable all warnings that are actionable by the user of this toolset
-    # style should enable the other 3, but we'll be explicit just in case
-    set(CMAKE_CXX_CPPCHECK
-        ${CPPCHECK}
-        --enable=style,performance,warning,portability
-        --inline-suppr
-        # We cannot act on a bug/missing feature of cppcheck
-        --suppress=internalAstError
-        # if a file does not have an internalAstError, we get an unmatchedSuppression error
-        --suppress=unmatchedSuppression
-        --inconclusive)
+
+    if("${CPPCHECK_OPTIONS}" STREQUAL "")
+      # Enable all warnings that are actionable by the user of this toolset
+      # style should enable the other 3, but we'll be explicit just in case
+      set(CMAKE_CXX_CPPCHECK
+          ${CPPCHECK}
+          --enable=style,performance,warning,portability
+          --inline-suppr
+          # We cannot act on a bug/missing feature of cppcheck
+          --suppress=internalAstError
+          # if a file does not have an internalAstError, we get an unmatchedSuppression error
+          --suppress=unmatchedSuppression
+          --inconclusive)
+    else()
+      set(CMAKE_CXX_CPPCHECK ${CPPCHECK} ${CPPCHECK_OPTIONS})
+    endif()
+
     if(NOT
        "${CMAKE_CXX_STANDARD}"
        STREQUAL


### PR DESCRIPTION
Follow the same pattern used by MSVC/Clang/Cuda/GCC, to allow the user to override the flags passed to cppcheck.

Notes:

 * This is not necessary or desired for clang-tidy because that is what the `.clang-tidy` configuration file is used for
 * Unfortunately cppcheck does not provide the same kind top-level configuration file from what I can find.
 * I am intentionally doing a full override of the options, not an addition, so we don't have to worry about conflicts

