### PR TITLE
fix: set ENABLE_DEVELOPER_MODE to OFF by default + report the building mode

### DIFF
--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -19,7 +19,18 @@
 # set(<feature_name>_DEVELOPER_DEFAULT <value>) - set default for developer mode
 # set(<feature_name>_USER_DEFAULT <value>) - set default for user mode
 
-option(ENABLE_DEVELOPER_MODE "Set up defaults for a developer of the project, and let developer change options" ON)
+option(ENABLE_DEVELOPER_MODE "Set up defaults for a developer of the project, and let developer change options" OFF)
+if(NOT ${ENABLE_DEVELOPER_MODE})
+  message(
+    STATUS
+      "Developer mode is off. For developement, use `-DENABLE_DEVELOPER_MODE:BOOL=ON`. Building the project for the end-user..."
+  )
+else()
+  message(
+    STATUS
+      "Developer mode is ON. For production, use `-DENABLE_DEVELOPER_MODE:BOOL=OFF`. Building the project for the developer..."
+  )
+endif()
 
 if((CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" OR CMAKE_CXX_COMPILER_ID MATCHES ".*GNU.*") AND NOT WIN32)
   set(SUPPORTS_UBSAN ON)

--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -23,7 +23,7 @@ option(ENABLE_DEVELOPER_MODE "Set up defaults for a developer of the project, an
 if(NOT ${ENABLE_DEVELOPER_MODE})
   message(
     STATUS
-      "Developer mode is off. For developement, use `-DENABLE_DEVELOPER_MODE:BOOL=ON`. Building the project for the end-user..."
+      "Developer mode is OFF. For developement, use `-DENABLE_DEVELOPER_MODE:BOOL=ON`. Building the project for the end-user..."
   )
 else()
   message(


### PR DESCRIPTION
We should not expect the **average user** of a library pass flags to be able to use a library. Instead, **the developer** who knows the ins and outs of the library should set the developer mode to ON. 

This not only affects the average end-users but also the **advanced users** that should go through the whole dependency tree and pass flags to each of them to make them usable as a dependency.

I should have paid attention to this in #46, but it is still not late to fix the default.