### PR TITLE
fix: correctly check if vsinstalldir is in $path on msvc

### DIFF
--- a/src/Sanitizers.cmake
+++ b/src/Sanitizers.cmake
@@ -70,8 +70,8 @@ function(
         target_compile_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
         target_link_options(${project_name} INTERFACE -fsanitize=${LIST_OF_SANITIZERS})
       else()
-        string(FIND "$ENV{VSINSTALLDIR}" "$ENV{PATH}" index_of_vs_install_dir)
-        if("index_of_vs_install_dir" STREQUAL "-1")
+        string(FIND "$ENV{PATH}" "$ENV{VSINSTALLDIR}" index_of_vs_install_dir)
+        if("${index_of_vs_install_dir}" STREQUAL "-1")
           message(
             SEND_ERROR
               "Using MSVC sanitizers requires setting the MSVC environment before building the project. Please manually open the MSVC command prompt and rebuild the project."


### PR DESCRIPTION
Before this commit having a falsly setup VSINSTALLDIR would not trigger the error. 
This had two reasons:
- first, the CMake string FIND module had the arguments mixed up
- second, the check itself never expanded the output variable from the string FIND

After this commit the error should be emitted if $VCINSTALLDIR is not in $PATH