### PR TITLE
fix: make Conan optional in dynamic_project_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ project(myproject LANGUAGES CXX C)
 # Set PCH to be on by default for all non-Developer Mode Builds
 set(ENABLE_PCH_USER_DEFAULT ON)
 
+# enable Conan
+set(ENABLE_CONAN_DEFAULT ON)
+
 # Initialize project_options variable related to this project
 # This overwrites `project_options` and sets `project_warnings`
 # This also accepts the same arguments as `project_options`.

--- a/src/DynamicProjectOptions.cmake
+++ b/src/DynamicProjectOptions.cmake
@@ -67,7 +67,7 @@ set(options
     "ENABLE_CACHE\;${MAKEFILE_OR_NINJA}\;${MAKEFILE_OR_NINJA}\;Enable ccache on Unix"
     "WARNINGS_AS_ERRORS\;OFF\;ON\;Treat warnings as Errors"
     "ENABLE_CLANG_TIDY\;OFF\;${MAKEFILE_OR_NINJA}\;Enable clang-tidy analysis during compilation"
-    "ENABLE_CONAN\;ON\;ON\;Automatically integrate Conan for package management"
+    "ENABLE_CONAN\;OFF\;OFF\;Automatically integrate Conan for package management"
     "ENABLE_COVERAGE\;OFF\;OFF\;Analyze and report on coverage"
     "ENABLE_SANITIZER_ADDRESS\;OFF\;${SUPPORTS_ASAN}\;Make memory errors into hard runtime errors (windows/linux/macos)"
     "ENABLE_SANITIZER_UNDEFINED_BEHAVIOR\;OFF\;${SUPPORTS_UBSAN}\;Make certain types (numeric mostly) of undefined behavior into runtime errors"


### PR DESCRIPTION
Many people use vcpkg

BREAKING CHANGE this requires adding `set(ENABLE_CONAN_DEFAULT ON)` before calling `dynamic_project_options`