### PR TITLE
fix: accept INTERFACE_* as an alias to PUBLIC_* in package_project

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ An executable:
 
 ```cmake
 add_executable(myprogram main.cpp)
-target_link_libraries(myprogram PRIVATE project_options project_warnings) # connect project_options to myprogram
+target_link_libraries(myprogram PRIVATE project_options project_warnings) # link project_options/warnings
 
 # Find dependencies:
 set(DEPENDENCIES_CONFIGURED fmt Eigen3)
@@ -86,7 +86,7 @@ A header-only library:
 
 ```cmake
 add_library(my_header_only_lib INTERFACE)
-target_link_libraries(my_header_only_lib INTERFACE project_options project_warnings) # connect project_options to my_header_only_lib
+target_link_libraries(my_header_only_lib INTERFACE project_options project_warnings) # link project_options/warnings
 
 # Includes
 set(INCLUDE_DIR "include") # must be relative paths
@@ -110,9 +110,9 @@ target_link_system_libraries(
 
 # Package the project
 package_project(
-  TARGETS my_header_only_lib
-  PUBLIC_DEPENDENCIES_CONFIGURED ${DEPENDENCIES_CONFIGURED}
-  PUBLIC_INCLUDES ${INCLUDE_DIR}
+  TARGETS my_header_only_lib project_options project_warnings
+  INTERFACE_DEPENDENCIES_CONFIGURED ${DEPENDENCIES_CONFIGURED}
+  INTERFACE_INCLUDES ${INCLUDE_DIR}
 )
 ```
 
@@ -120,7 +120,7 @@ A library with separate header and source files
 
 ```cmake
 add_library(my_lib "./src/my_lib/lib.cpp")
-target_link_libraries(my_lib INTERFACE project_options project_warnings) # connect project_options to my_lib
+target_link_libraries(my_lib PRIVATE project_options project_warnings) # link project_options/warnings
 
 # Includes
 set(INCLUDE_DIR "include") # must be relative paths
@@ -145,7 +145,7 @@ target_link_system_libraries(
 # Package the project
 package_project(
   TARGETS my_lib
-  PUBLIC_INCLUDES ${INCLUDE_DIR}
+  INTERFACE_INCLUDES ${INCLUDE_DIR}
 )
 ```
 
@@ -226,13 +226,13 @@ The following arguments specify the package:
 
 - `TARGETS`: the targets you want to package. It is recursively found for the current folder if not specified
 
-- `PUBLIC_INCLUDES`: a list of public/interface include directories or files. 
+- `INTERFACE_INCLUDES` or `PUBLIC_INCLUDES`: a list of interface/public include directories or files.
 
   <sub>NOTE: The given include directories are directly installed to the install destination. To have an `include` folder in the install destination with the content of your include directory, name your directory `include`.</sub>
 
-- `PUBLIC_DEPENDENCIES_CONFIGURED`: the names of the INTERFACE/PUBLIC dependencies that are found using `CONFIG`.
+- `INTERFACE_DEPENDENCIES_CONFIGURED` or `PUBLIC_DEPENDENCIES_CONFIGURED`: the names of the interface/public dependencies that are found using `CONFIG`.
 
-- `PUBLIC_DEPENDENCIES`: the INTERFACE/PUBLIC dependencies that are found by any means using `find_dependency`. The arguments must be specified within quotes (e.g. `"<dependency> 1.0.0 EXACT"` or `"<dependency> CONFIG"`).
+- `INTERFACE_DEPENDENCIES` or `PUBLIC_DEPENDENCIES`: the interface/public dependencies that will be found by any means using `find_dependency`. The arguments must be specified within quotes (e.g.`"<dependency> 1.0.0 EXACT"` or `"<dependency> CONFIG"`).
 
 - `PRIVATE_DEPENDENCIES_CONFIGURED`: the names of the PRIVATE dependencies found using `CONFIG`. Only included when `BUILD_SHARED_LIBS` is `OFF`.
 

--- a/src/PackageProject.cmake
+++ b/src/PackageProject.cmake
@@ -21,11 +21,14 @@ function(package_project)
       # recursively found for the current folder if not specified
       TARGETS
       # a list of public/interface include directories or files
+      INTERFACE_INCLUDES
       PUBLIC_INCLUDES
       # the names of the INTERFACE/PUBLIC dependencies that are found using `CONFIG`
+      INTERFACE_DEPENDENCIES_CONFIGURED
       PUBLIC_DEPENDENCIES_CONFIGURED
       # the INTERFACE/PUBLIC dependencies that are found by any means using `find_dependency`.
       # the arguments must be specified within double quotes (e.g. "<dependency> 1.0.0 EXACT" or "<dependency> CONFIG").
+      INTERFACE_DEPENDENCIES
       PUBLIC_DEPENDENCIES
       # the names of the PRIVATE dependencies that are found using `CONFIG`. Only included when BUILD_SHARED_LIBS is OFF.
       PRIVATE_DEPENDENCIES_CONFIGURED
@@ -81,6 +84,7 @@ function(package_project)
   set(_PackageProject_INSTALL_DESTINATION "${_PackageProject_CONFIG_INSTALL_DESTINATION}")
 
   # Installation of the public/interface includes
+  set(_PackageProject_PUBLIC_INCLUDES "${_PackageProject_PUBLIC_INCLUDES}" "${_PackageProject_INTERFACE_INCLUDES}")
   if(NOT
      "${_PackageProject_PUBLIC_INCLUDES}"
      STREQUAL
@@ -101,6 +105,8 @@ function(package_project)
   endif()
 
   # Append the configured public dependencies
+  set(_PackageProject_PUBLIC_DEPENDENCIES_CONFIGURED "${_PackageProject_PUBLIC_DEPENDENCIES_CONFIGURED}"
+                                                     "${_PackageProject_INTERFACE_DEPENDENCIES_CONFIGURED}")
   if(NOT
      "${_PackageProject_PUBLIC_DEPENDENCIES_CONFIGURED}"
      STREQUAL
@@ -112,7 +118,7 @@ function(package_project)
   endif()
   list(APPEND _PackageProject_PUBLIC_DEPENDENCIES ${_PUBLIC_DEPENDENCIES_CONFIG})
   # ycm arg
-  set(_PackageProject_DEPENDENCIES ${_PackageProject_PUBLIC_DEPENDENCIES})
+  set(_PackageProject_DEPENDENCIES ${_PackageProject_PUBLIC_DEPENDENCIES} ${_PackageProject_INTERFACE_DEPENDENCIES})
 
   # Append the configured private dependencies
   if(NOT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,9 +98,9 @@ package_project(
   # lib
   # project_warnings
   # project_options
-  PUBLIC_DEPENDENCIES_CONFIGURED
+  INTERFACE_DEPENDENCIES_CONFIGURED
   ${DEPENDENCIES_CONFIGURED}
-  PUBLIC_INCLUDES
+  INTERFACE_INCLUDES
   ${INCLUDE_DIR})
 
 # package separately (for testing)
@@ -109,9 +109,9 @@ package_project(
   myproj_header_only_lib
   TARGETS
   lib
-  PUBLIC_DEPENDENCIES_CONFIGURED
+  INTERFACE_DEPENDENCIES_CONFIGURED
   ${DEPENDENCIES_CONFIGURED}
-  PUBLIC_INCLUDES
+  INTERFACE_INCLUDES
   ${INCLUDE_DIR})
 
 package_project(
@@ -119,7 +119,7 @@ package_project(
   myproj_lib
   TARGETS
   lib2
-  PUBLIC_INCLUDES
+  INTERFACE_INCLUDES
   ${INCLUDE_DIR2})
 
 package_project(


### PR DESCRIPTION
These are treated the same during installation, but accepting both removes confusion for the users