### PR TITLE
fix: remove non-C warnings for C

### DIFF
--- a/src/CompilerWarnings.cmake
+++ b/src/CompilerWarnings.cmake
@@ -99,8 +99,15 @@ function(
     # TODO support Intel compiler
   endif()
 
-  # use the same warning flags for C
+  # Add C warnings
   set(PROJECT_WARNINGS_C "${PROJECT_WARNINGS_CXX}")
+  list(
+    REMOVE_ITEM
+    PROJECT_WARNINGS_C
+    -Wnon-virtual-dtor
+    -Wold-style-cast
+    -Woverloaded-virtual
+    -Wuseless-cast)
 
   set(PROJECT_WARNINGS_CUDA "${CUDA_WARNINGS}")
 


### PR DESCRIPTION
Fixes #69 